### PR TITLE
Add location to scan results

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,27 +41,32 @@ A valid result will return a response like
     activity: [{
             date: 'Sep 27, 2017',
             time: '3:16pm',
-            action: 'Goods delivered: Signed for by:ROB'
+            action: 'Goods delivered: Signed for by:ROB',
+            location: 'Australia'
         },
         {
             date: 'Sep 27, 2017',
             time: '12:00pm',
-            action: 'On-board for delivery'
+            action: 'On-board for delivery',
+            location: 'Australia'
         },
         {
             date: 'Sep 27, 2017',
             time: '5:41am',
-            action: 'Arrive at destination depot in transit'
+            action: 'Arrive at destination depot in transit',
+            location: 'Australia'
         },
         {
             date: 'Sep 25, 2017',
             time: '11:24am',
-            action: 'Transfer to new depot'
+            action: 'Transfer to new depot',
+            location: 'Australia'
         },
         {
             date: 'Sep 25, 2017',
             time: '10:50am',
-            action: 'Picked Up'
+            action: 'Picked Up',
+            location: 'Australia'
         }
     ]
 }

--- a/helpers/normalize.js
+++ b/helpers/normalize.js
@@ -83,7 +83,8 @@ function transform(res) {
         date: isoDate.date,
         time: isoDate.time,
         value: isoDate.value,
-        action: parseAction(info.action.trim())
+        action: parseAction(info.action.trim()),
+        location: "Australia"
       };
       if (info.action.indexOf("Picked Up") != -1) {
         pickedupAt = { date: isoDate.date, time: isoDate.time };


### PR DESCRIPTION
This is to be consistent with other trackers that return location
results of where the scan happened.

Defaults to 'Australia' in this case.